### PR TITLE
Rename default agent from 'hermy'/'default' to 'operator'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ defaults:
   # env_file: "~/.env"        # Load API keys from a dotenv file
 
 agents:
-  default:
+  operator:
     transport:
       type: slack
       bot_token_env: SLACK_BOT_TOKEN
@@ -82,13 +82,13 @@ defaults:
   env_file: "~/.env"
 
 agents:
-  hermy:
+  operator:
     models:
       - "anthropic/claude-sonnet-4-6"
     transport:
       type: slack
-      bot_token_env: SLACK_BOT_TOKEN_HERMY
-      app_token_env: SLACK_APP_TOKEN_HERMY
+      bot_token_env: SLACK_BOT_TOKEN
+      app_token_env: SLACK_APP_TOKEN
 ```
 
 `models` is a fallback chain — if the first model errors (overloaded, rate limited, down), the next is tried automatically. Always use list format, even for a single model.
@@ -264,7 +264,7 @@ Each job is `~/.operator/jobs/<name>/JOB.md` with YAML frontmatter and markdown 
 name: daily-summary
 description: Summarize today's activity
 schedule: "0 9 * * *"
-agent: hermy
+agent: operator
 model: "anthropic/claude-sonnet-4-6"
 hooks:
   prerun: scripts/check.sh

--- a/src/operator_ai/cli.py
+++ b/src/operator_ai/cli.py
@@ -86,7 +86,7 @@ defaults:
   # env_file: "~/.env"           # Load API keys from a dotenv file
 
 agents:
-  default:
+  operator:
     transport:
       type: slack
       bot_token_env: SLACK_BOT_TOKEN
@@ -112,7 +112,7 @@ You are a helpful assistant managed by Operator.
 """
 
 _STARTER_AGENT_MD = """\
-# Default Agent
+# Operator Agent
 
 You are a helpful assistant.
 """
@@ -132,7 +132,7 @@ def init() -> None:
     dirs = [
         home / "logs",
         home / "state",
-        home / "agents" / "default" / "workspace",
+        home / "agents" / "operator" / "workspace",
         home / "jobs",
         home / "skills",
     ]
@@ -144,7 +144,7 @@ def init() -> None:
     files: list[tuple[Path, str]] = [
         (config_file, _STARTER_CONFIG),
         (home / "SYSTEM.md", _STARTER_SYSTEM_MD),
-        (home / "agents" / "default" / "AGENT.md", _STARTER_AGENT_MD),
+        (home / "agents" / "operator" / "AGENT.md", _STARTER_AGENT_MD),
     ]
     for path, content in files:
         if path.exists():

--- a/src/operator_ai/config.py
+++ b/src/operator_ai/config.py
@@ -226,7 +226,7 @@ class Config(BaseModel):
         """Return the first agent name from config, or 'default'."""
         if self.agents:
             return next(iter(self.agents))
-        return "default"
+        return "operator"
 
 
 def _load_env_file(env_path: str, *, base_dir: Path | None = None) -> None:

--- a/src/operator_ai/prompts/harvester.md
+++ b/src/operator_ai/prompts/harvester.md
@@ -10,7 +10,7 @@ Do not include any commentary, headings, numbering, or untagged lines.
 
 Example output:
 - [user] Gavin's timezone is America/Toronto
-- [agent] The cron daemon needs hermy's API key to run
+- [agent] The cron daemon needs operator's API key to run
 - [global] The project uses Python 3.11
 
 Conversation:

--- a/tests/test_job_specs.py
+++ b/tests/test_job_specs.py
@@ -17,7 +17,7 @@ def test_scan_job_specs_reads_frontmatter_fields(tmp_path: Path) -> None:
         """---
 name: daily-summary
 schedule: "0 9 * * *"
-agent: hermy
+agent: operator
 enabled: false
 description: Morning digest
 model: "openai/gpt-4o"
@@ -31,7 +31,7 @@ Run a summary.
     spec = specs[0]
     assert spec.name == "daily-summary"
     assert spec.schedule == "0 9 * * *"
-    assert spec.agent == "hermy"
+    assert spec.agent == "operator"
     assert spec.enabled is False
     assert spec.description == "Morning digest"
     assert spec.model == "openai/gpt-4o"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -14,7 +14,7 @@ def _configure_public_context(fake_memory_store) -> None:
         {
             "memory_store": fake_memory_store,
             "user_id": "slack:U123",
-            "agent_name": "hermy",
+            "agent_name": "operator",
             "allow_user_scope": False,
         }
     )
@@ -37,7 +37,7 @@ def test_search_memories_default_scope_excludes_user_in_public_context(
 
     assert fake_memory_store.search_calls
     assert fake_memory_store.search_calls[0]["scopes"] == [
-        ("agent", "hermy"),
+        ("agent", "operator"),
         ("global", "global"),
     ]
 
@@ -45,7 +45,7 @@ def test_search_memories_default_scope_excludes_user_in_public_context(
 def test_list_memories_in_public_context_filters_to_agent_and_global(
     fake_memory_store,
 ) -> None:
-    fake_memory_store.scoped_lists[("agent", "hermy")] = [
+    fake_memory_store.scoped_lists[("agent", "operator")] = [
         {"id": 2, "content": "agent note", "scope": "agent", "pinned": 0}
     ]
     fake_memory_store.scoped_lists[("global", "global")] = [
@@ -69,7 +69,7 @@ def test_parse_harvested_line_rejects_user_scope_when_not_private() -> None:
     parsed = _parse_harvested_line(
         "- [user] Gavin likes espresso",
         user_id="slack:U123",
-        agent_name="hermy",
+        agent_name="operator",
         allow_user_scope=False,
     )
     assert parsed is None
@@ -79,14 +79,14 @@ def test_parse_harvested_line_accepts_agent_and_global_when_not_private() -> Non
     parsed_agent = _parse_harvested_line(
         "- [agent] Project uses uv",
         user_id="",
-        agent_name="hermy",
+        agent_name="operator",
         allow_user_scope=False,
     )
     parsed_global = _parse_harvested_line(
         "- [global] Python 3.11 is required",
         user_id="",
-        agent_name="hermy",
+        agent_name="operator",
         allow_user_scope=False,
     )
-    assert parsed_agent == ("agent", "hermy", "Project uses uv")
+    assert parsed_agent == ("agent", "operator", "Project uses uv")
     assert parsed_global == ("global", "global", "Python 3.11 is required")


### PR DESCRIPTION
## Summary
- Renamed the starter config agent from `default` to `operator` in `cli.py`
- Updated `_STARTER_AGENT_MD` header to "# Operator Agent"
- Changed scaffold directory paths from `agents/default/` to `agents/operator/`
- Updated `config.py` fallback in `default_agent()` from `"default"` to `"operator"`
- Replaced `hermy` references in `harvester.md`, test fixtures, and README examples

Closes #2

## Test plan
- [x] All 14 tests pass (lint + pytest via pre-commit hook)
- [x] No remaining `hermy` references in `src/` or `tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)